### PR TITLE
Bug/refresh trail page upon successful image submission

### DIFF
--- a/client/src/helpers/helpers.js
+++ b/client/src/helpers/helpers.js
@@ -181,7 +181,10 @@ module.exports.submitImage = function(e) {
       trail_id: this.state.trailId,
     };
     return axios.post('/api/posts', {photo: metaPhoto})
-      .then(res => console.log('success: ', res))
+      .then((res) => {
+        console.log('success: ', res);
+        refreshPage();
+    })
       .catch(err => console.log('error in the /api/posts endpoint: ', err));
   })
   .catch((err, res) => {

--- a/client/src/helpers/helpers.js
+++ b/client/src/helpers/helpers.js
@@ -161,6 +161,10 @@ module.exports.handlePlacesChanged = function ()  {
   this.onDragEnd({});
  }
 
+function refreshPage() {
+   window.location.reload();
+ }
+
 module.exports.submitImage = function(e) {
   e.preventDefault();
   var form = new FormData();


### PR DESCRIPTION
## Update to bug fix: 
- Originally: whenever a user uploaded an image successfully, trail page would not refresh with newly uploaded image 
- Now: trail page will refresh with newly uploaded image